### PR TITLE
[MG-22] feat : 메일 삭제 API 구현

### DIFF
--- a/mailgreen-db/migrations/versions/cf3be5d7a091_modify_mail_embeddings_drop_carbon__add_.py
+++ b/mailgreen-db/migrations/versions/cf3be5d7a091_modify_mail_embeddings_drop_carbon__add_.py
@@ -1,0 +1,71 @@
+"""modify mail_embeddings: drop carbon_*, add is_deleted & deleted_at
+
+Revision ID: cf3be5d7a091
+Revises: 311ee75c0e9f
+Create Date: 2025-05-31 17:26:03.700500
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "cf3be5d7a091"
+down_revision: Union[str, None] = "311ee75c0e9f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    # carbon_factor, carbon_saved_grams 컬럼 제거
+    op.drop_column("mail_embeddings", "carbon_factor")
+    op.drop_column("mail_embeddings", "carbon_saved_grams")
+
+    # is_deleted, deleted_at 컬럼 추가
+    op.add_column(
+        "mail_embeddings",
+        sa.Column(
+            "is_deleted", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+    )
+    op.add_column(
+        "mail_embeddings",
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    # is_deleted 인덱스 생성
+    op.create_index(
+        "ix_mail_embeddings_is_deleted",
+        "mail_embeddings",
+        ["is_deleted"],
+    )
+
+
+def downgrade():
+    # 롤백 시, 추가했던 것들을 역순으로 제거/복원
+    op.drop_index("ix_mail_embeddings_is_deleted", table_name="mail_embeddings")
+    op.drop_column("mail_embeddings", "deleted_at")
+    op.drop_column("mail_embeddings", "is_deleted")
+
+    # carbon_factor, carbon_saved_grams 컬럼 다시 추가
+    op.add_column(
+        "mail_embeddings",
+        sa.Column(
+            "carbon_saved_grams",
+            sa.Float(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+    op.add_column(
+        "mail_embeddings",
+        sa.Column(
+            "carbon_factor",
+            sa.Float(),
+            nullable=False,
+            server_default=sa.text("0.00002"),
+        ),
+    )

--- a/mailgreen/app/models.py
+++ b/mailgreen/app/models.py
@@ -1,15 +1,5 @@
 import datetime, enum
-from sqlalchemy import (
-    Column,
-    String,
-    Text,
-    Boolean,
-    Integer,
-    DateTime,
-    Float,
-    UUID,
-    JSON,
-)
+from sqlalchemy import Column, String, Text, Boolean, Integer, DateTime, UUID, Index
 from sqlalchemy.orm import declarative_base
 from sqlalchemy.dialects.postgresql import UUID as PGUUID, ARRAY, TIMESTAMP
 from pgvector.sqlalchemy import Vector
@@ -52,9 +42,14 @@ class MailEmbedding(Base):
     received_at = Column(DateTime(timezone=True))
     vector = Column(Vector(384))
     keywords = Column(ARRAY(Text))
-    carbon_factor = Column(Float, default=0.00002)
-    carbon_saved_grams = Column(Float, default=0)
     processed_at = Column(DateTime(timezone=True), default=datetime.datetime.utcnow)
+
+    # Soft-Delete
+    is_deleted = Column(Boolean, nullable=False, server_default="false")
+    deleted_at = Column(DateTime(timezone=True), nullable=True)
+
+    # is_deleted 컬럼 인덱스 > 삭제되지 않은 레코드 빠르게 조회
+    __table_args__ = (Index("ix_mail_embeddings_is_deleted", "is_deleted"),)
 
 
 class AnalysisTask(Base):
@@ -77,4 +72,3 @@ class UserCredentials(Base):
     access_token = Column(String, nullable=False)
     refresh_token = Column(String, nullable=False)
     expiry = Column(DateTime, nullable=False)
-    scopes = Column(JSON, nullable=False, server_default="[]")

--- a/mailgreen/controller/auth_controller.py
+++ b/mailgreen/controller/auth_controller.py
@@ -18,7 +18,7 @@ oauth.register(
     client_secret=os.getenv("GOOGLE_CLIENT_SECRET"),
     server_metadata_url="https://accounts.google.com/.well-known/openid-configuration",
     client_kwargs={
-        "scope": "openid email profile https://www.googleapis.com/auth/gmail.readonly"
+        "scope": "openid email profile https://www.googleapis.com/auth/gmail.modify"
     },
     authorize_params={"access_type": "offline", "prompt": "consent"},
 )

--- a/mailgreen/controller/mail_controller.py
+++ b/mailgreen/controller/mail_controller.py
@@ -96,7 +96,7 @@ async def get_top_senders(
 @router.get("/sender")
 async def get_sender_details(
     user_id: str = Query(..., description="User UUID"),
-    sender: str = Query(..., description="발신자 이메일 or 이름"),
+    sender: str | None = Query(None, description="발신자 이메일 or 이름"),
     start_date: str | None = Query(None, description="조회 시작일 (YYYY-MM-DD)"),
     end_date: str | None = Query(None, description="조회 종료일 (YYYY-MM-DD)"),
     is_read: bool | None = Query(None, description="읽음 여부 필터 (true/false)"),
@@ -111,8 +111,11 @@ async def get_sender_details(
     # 기본 sender/UUID 필터
     query = db.query(MailEmbedding).filter(
         MailEmbedding.user_id == user_id,
-        MailEmbedding.sender.ilike(f"%{sender}%"),
     )
+
+    # sender가 있는 경우에만 필터 추가
+    if sender:
+        query = query.filter(MailEmbedding.sender.ilike(f"%{sender}%"))
 
     # 날짜 범위 필터
     if start_date:

--- a/mailgreen/controller/mail_controller.py
+++ b/mailgreen/controller/mail_controller.py
@@ -1,12 +1,17 @@
 import uuid
 from datetime import datetime, timezone
+from googleapiclient.discovery import build
+from typing import List
 from uuid import UUID
 
 from dateutil.relativedelta import relativedelta
-from fastapi import Depends, APIRouter, Query, HTTPException
+from fastapi import Depends, APIRouter, Query, HTTPException, Body
+from googleapiclient.errors import HttpError
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from mailgreen.app.database import get_db
+from mailgreen.services.mail_service import get_credentials
 from mailgreen.tasks.mail_analysis import run_analysis
 from mailgreen.app.models import AnalysisTask, MailEmbedding
 
@@ -177,3 +182,96 @@ async def get_sender_details(
         }
         for m in mails
     ]
+
+
+class DeleteMailsRequest(BaseModel):
+    message_ids: List[str]
+    confirm: bool = False  # false면 삭제하지 않고 추정만
+
+
+@router.delete("/trash")
+async def trash_mails(
+    user_id: str = Query(..., description="User UUID"),
+    payload: DeleteMailsRequest = Body(
+        ..., description="삭제할 메일 ID 목록과 확인 여부"
+    ),
+    db: Session = Depends(get_db),
+):
+    creds = get_credentials(user_id)
+    service = build("gmail", "v1", credentials=creds)
+
+    # 탄소량 (메일 하나당 4g 절감)
+    CO2_PER_EMAIL_G = 4.0
+
+    count = len(payload.message_ids)
+    estimated_saved = round(count * CO2_PER_EMAIL_G, 2)
+
+    deleted_ids = []
+    errors = []
+
+    # confirm=False
+    if not payload.confirm:
+        for gmail_msg_id in payload.message_ids:
+            deleted_ids.append(f"{gmail_msg_id} (dry-run)")
+        return {
+            "requested_count": count,
+            "deleted": False,
+            "estimated_carbon_saved_g": estimated_saved,
+            "deleted_ids": deleted_ids,
+            "errors": [],
+        }
+
+    # confirm=True인 경우: 실제 삭제 수행
+    for gmail_msg_id in payload.message_ids:
+        try:
+            # Gmail API 호출: 메일을 휴지통으로 이동
+            service.users().messages().trash(userId="me", id=gmail_msg_id).execute()
+            deleted_ids.append(gmail_msg_id)
+        except HttpError as e:
+            # Gmail API 호출 실패
+            error_detail = None
+            try:
+                error_detail = e.error_details or e.content.decode()
+            except:
+                pass
+            errors.append(
+                {
+                    "msg_id": gmail_msg_id,
+                    "error": f"Gmail API 에러: {str(e)}",
+                    "details": error_detail,
+                }
+            )
+            # 다음 ID 처리로 넘어감
+            continue
+
+        # DB 업데이트: MailEmbedding 레코드에 is_deleted=True, deleted_at=현재 시각
+        record = (
+            db.query(MailEmbedding)
+            .filter(MailEmbedding.gmail_msg_id == gmail_msg_id)
+            .first()
+        )
+        if record:
+            record.is_deleted = True
+            record.deleted_at = datetime.utcnow()
+        else:
+            # DB에 해당 레코드가 없으면
+            errors.append(
+                {
+                    "msg_id": gmail_msg_id,
+                    "error": "DB에서 해당 Gmail 메시지 ID를 찾을 수 없습니다.",
+                }
+            )
+
+    try:
+        db.commit()
+    except Exception as db_err:
+        db.rollback()
+        raise HTTPException(status_code=500, detail=f"DB 업데이트 실패: {str(db_err)}")
+
+    return {
+        "requested_count": count,
+        "deleted": True,
+        "estimated_carbon_saved_g": estimated_saved,
+        "deleted_ids": deleted_ids,
+        "errors": errors,
+    }

--- a/mailgreen/services/mail_service.py
+++ b/mailgreen/services/mail_service.py
@@ -28,7 +28,6 @@ def get_credentials(user_id: str) -> Credentials:
             token_uri="https://oauth2.googleapis.com/token",
             client_id=os.getenv("GOOGLE_CLIENT_ID"),
             client_secret=os.getenv("GOOGLE_CLIENT_SECRET"),
-            scopes=cred.scopes,  # 기존 스코프도 로드
             expiry=cred.expiry,
         )
         # 만료되었으면 리프레시
@@ -37,7 +36,6 @@ def get_credentials(user_id: str) -> Credentials:
             # DB에 갱신된 토큰/만료시간 저장
             cred.access_token = creds.token
             cred.expiry = creds.expiry.replace(tzinfo=timezone.utc)
-            cred.scopes = creds.scopes  # ← 새 스코프 반영
             db.commit()
         return creds
     finally:

--- a/mailgreen/services/mail_service.py
+++ b/mailgreen/services/mail_service.py
@@ -75,6 +75,7 @@ def batch_fetch_metadata(
         if err:
             logger.warning(f"Batch fetch error for {request_id}: {err}")
             return
+        label_ids = resp.get("labelIds", [])
         mails.append(
             {
                 "id": resp["id"],
@@ -93,7 +94,9 @@ def batch_fetch_metadata(
                     int(resp["internalDate"]) / 1000, timezone.utc
                 ).isoformat(),
                 "size": resp.get("sizeEstimate", 0),
-                "isRead": "UNREAD" not in resp.get("labelIds", []),
+                "labels": label_ids,
+                "isRead": "UNREAD" not in label_ids,
+                "isStarred": "STARRED" in label_ids,
             }
         )
 

--- a/mailgreen/tasks/mail_analysis.py
+++ b/mailgreen/tasks/mail_analysis.py
@@ -72,6 +72,8 @@ def run_analysis(
                 snippet=mail["snippet"],
                 size_bytes=mail["size"],
                 is_read=mail["isRead"],
+                is_starred=mail["isStarred"],
+                labels=mail["labels"],
                 received_at=datetime.fromisoformat(mail["timestamp"]),
                 vector=get_embedding(mail["subject"] + " " + mail["snippet"]),
                 processed_at=datetime.now(timezone.utc),


### PR DESCRIPTION
✨ New Features

메일 휴지통 이동(삭제) 기능 추가

- `confirm=false`일 때
    - 실제 삭제 없이 예상 삭제 ID 목록만 반환
- `confirm=true`일 때
    - Gmail API 호출로 요청된 메시지들을 휴지통으로 이동
    - `MailEmbedding` 레코드에 `is_deleted=True` 및 `deleted_at` 업데이트
- Gmail API 호출 중 에러 발생 시
    
    에러가 발생한 메시지 ID를 기록하고, 남은 메시지 ID의 처리를 계속 진행
    
    ```json
    { 
      "msg_id": "<실패한 메시지 ID>",
      "error": "Gmail API 에러: <예외 메시지>",
      "details": "<Gmail API 응답 상세 정보>"
    }
    ```
    
- DB에서 메시지 ID를 찾을 수 없을 때
    
    에러가 발생한 메시지 ID를 기록하고, 남은 메시지 ID의 처리를 계속 진행
    
    ```json
    {
      "msg_id": "<메시지 ID>",
      "error": "DB에서 해당 Gmail 메시지 ID를 찾을 수 없습니다."
    }
    ```
    
- DB 트랜잭션 커밋 실패 시
    
    수행한 모든 DB 업데이트 롤백, `HTTP 500 Internal Server Error` 반환

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an endpoint to delete (trash) emails via Gmail integration, supporting dry-run and confirmed modes.
  - Enhanced mail progress endpoint to include explicit status and error messages.
  - Added support for tracking and filtering starred emails and their labels.

- **Improvements**
  - Sender filter in the sender details endpoint is now optional.
  - Optimized database queries related to deleted emails.

- **Bug Fixes**
  - Fixed redirect URL formatting in authentication flow.

- **Other Changes**
  - Removed carbon tracking and scopes fields from emails and user credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->