### PR TITLE
[MG-18] feat : 발신자, 키워드 필터링 API 구현 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ __pycache__/
 *.py[cod]
 .venv/
 .env
+
+fastapi.log
+glances.log

--- a/mailgreen/controller/keyword_controller.py
+++ b/mailgreen/controller/keyword_controller.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from mailgreen.app.database import get_db
 from mailgreen.app.schemas.keyword import TopKeywordOut
 from mailgreen.app.schemas.mail import MailOut
-from mailgreen.services.keyword_service import get_top_keywords, get_keyword_details
+from mailgreen.services.keyword_service import get_top_keywords, get_keyword_details, get_keyword_details_count
 
 router = APIRouter(prefix="/keyword", tags=["keyword"])
 
@@ -56,3 +56,26 @@ async def keyword_details(
         )
         for m in mails
     ]
+
+@router.get('/counts')
+async def keyword_sender_counts(
+    user_id: str = Query(..., description="User UUID"),
+    topic_id: int | None = Query(None, description="조회할 대주제 ID (MajorTopic.id)"),
+    start_date: str | None = Query(None, description="조회 시작일 (YYYY-MM-DD)"),
+    end_date: str | None = Query(None, description="조회 종료일 (YYYY-MM-DD)"),
+    is_read: bool | None = Query(None, description="읽음 여부 필터 (true/false)"),
+    older_than_months: int | None = Query(None, description="지정 개월 이전 메일만 조회"),
+    min_size_mb: float | None = Query(None, description="필터 기준 메일 크기 (MB 단위)"),
+    db: Session = Depends(get_db),
+):
+    result = get_keyword_details_count(
+        db,
+        user_id,
+        topic_id=topic_id,
+        start_date=start_date,
+        end_date=end_date,
+        is_read=is_read,
+        older_than_months=older_than_months,
+        min_size_mb=min_size_mb,
+    )
+    return result

--- a/mailgreen/controller/sender_controller.py
+++ b/mailgreen/controller/sender_controller.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 
 from mailgreen.app.database import get_db
 from mailgreen.app.schemas.mail import MailOut
-from mailgreen.services.mail_service import get_top_senders, get_sender_details
+from mailgreen.services.mail_service import get_top_senders, get_sender_details, get_sender_details_count
 
 router = APIRouter(prefix="/sender", tags=["sender"])
 
@@ -54,3 +54,30 @@ async def sender_details(
         )
         for m in mails
     ]
+
+@router.get("/counts")
+async def get_sender_counts(
+    user_id: str = Query(..., description="User UUID"),
+     sender: Optional[str] = Query(None, description="발신자 이메일 or 이름"),
+    start_date: Optional[str] = Query(None, description="조회 시작일 (YYYY-MM-DD)"),
+    end_date: Optional[str] = Query(None, description="조회 종료일 (YYYY-MM-DD)"),
+    is_read: Optional[bool] = Query(None, description="읽음 여부 필터 (true/false)"),
+    older_than_months: Optional[int] = Query(
+        None, description="지정 개월 이전 메일만 조회"
+    ),
+    min_size_mb: Optional[float] = Query(
+        None, description="필터 기준 메일 크기 (MB 단위)"
+    ),
+    db: Session = Depends(get_db),
+): 
+    
+    return get_sender_details_count(
+        db,
+        user_id,
+        sender,
+        start_date,
+        end_date,
+        is_read,
+        older_than_months,
+        min_size_mb
+    )

--- a/mailgreen/services/keyword_service.py
+++ b/mailgreen/services/keyword_service.py
@@ -62,3 +62,99 @@ def get_keyword_details(
     )
 
     return query.order_by(MailEmbedding.received_at.desc()).all()
+
+
+def get_keyword_details_count(
+    db: Session,
+    user_id: str,
+    topic_id: int | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    is_read: bool | None = None,
+    older_than_months: int | None = None,
+    min_size_mb: float | None = None,
+) -> List[dict]:
+    from sqlalchemy.orm import aliased
+    from email.utils import parseaddr
+    # 기본 쿼리 구성
+    base_query = db.query(MailEmbedding).filter(
+        MailEmbedding.user_id == user_id,
+        MailEmbedding.is_deleted == False,
+        MailEmbedding.category.isnot(None),
+    )
+
+    if topic_id is not None:
+        base_query = base_query.filter(MailEmbedding.category == topic_id)
+
+    base_query = filter_mails(
+        base_query,
+        start_date=start_date,
+        end_date=end_date,
+        is_read=is_read,
+        older_than_months=older_than_months,
+        min_size_mb=min_size_mb,
+    )
+
+    # 카테고리 + sender 별 count
+    sender_counts = (
+        base_query.with_entities(
+            MailEmbedding.category.label("category"),
+            MailEmbedding.sender.label("sender"),
+            func.count(MailEmbedding.id).label("sender_count")
+        )
+        .group_by(MailEmbedding.category, MailEmbedding.sender)
+        .subquery()
+    )
+
+    # top sender 추출 (self left outer join with no greater count)
+    s1 = aliased(sender_counts)
+    s2 = aliased(sender_counts)
+
+    top_senders = (
+        db.query(s1.c.category, s1.c.sender)
+        .outerjoin(
+            s2,
+            (s1.c.category == s2.c.category) &
+            (s1.c.sender_count < s2.c.sender_count)
+        )
+        .filter(s2.c.category == None)
+        .subquery()
+    )
+
+    # 카테고리별 전체 개수
+    result_rows = (
+        base_query
+        .join(MajorTopic, MailEmbedding.category == MajorTopic.id)
+        .with_entities(
+            MajorTopic.id.label("category"),
+            MajorTopic.description.label("description"),
+            func.count(MailEmbedding.id).label("count")
+        )
+        .group_by(MajorTopic.id, MajorTopic.description)
+        .subquery()
+    )
+
+    # 최종 조인
+    final = (
+        db.query(
+            result_rows.c.category,
+            result_rows.c.description,
+            result_rows.c.count,
+            top_senders.c.sender.label("top_sender")
+        )
+        .outerjoin(top_senders, result_rows.c.category == top_senders.c.category)
+        .order_by(result_rows.c.count.desc())
+        .all()
+    )
+
+    result = []
+    for row in final:
+        name, email = parseaddr(row.top_sender or "")
+        result.append({
+            "topic_id": row.category,
+            "description": row.description,
+            "count": row.count,
+            "top_sender_name": name if name else None,
+            "top_sender_addr": email if email else None,
+        })
+    return result

--- a/mailgreen/services/mail_service.py
+++ b/mailgreen/services/mail_service.py
@@ -105,6 +105,52 @@ def get_sender_details(
     return query.order_by(MailEmbedding.received_at.desc()).all()
 
 
+def get_sender_details_count(
+    db: Session,
+    user_id: str,
+    sender: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    is_read: Optional[bool] = None,
+    older_than_months: Optional[int] = None,
+    min_size_mb: Optional[float] = None,
+) -> List[dict]:
+    
+    from sqlalchemy import func
+    from email.utils import parseaddr
+
+    query = db.query(
+        MailEmbedding.sender.label("sender"),
+        func.count(MailEmbedding.id).label("count"),
+    ).filter(MailEmbedding.user_id == user_id)
+
+    if sender:
+        query = query.filter(MailEmbedding.sender.ilike(f"%{sender}%"))
+
+    query = filter_mails(
+        query,
+        start_date=start_date,
+        end_date=end_date,
+        is_read=is_read,
+        older_than_months=older_than_months,
+        min_size_mb=min_size_mb,
+    )
+
+    rows = (
+        query.group_by(MailEmbedding.sender)
+        .order_by(func.count(MailEmbedding.id).desc())
+        .all()
+    )
+
+    result = []
+    for r in rows:
+        name, _ = parseaddr(r.sender or "")
+        sender_name = name if name else "(Unknown)"
+        result.append({"sender": r.sender, "name": sender_name, "count": r.count})
+    
+    return result
+
+
 CO2_PER_EMAIL_G = 4.0  # 메일 하나당 절감 탄소량(g)
 
 


### PR DESCRIPTION
## 📝 PR 타입

- [x] 기능 구현
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항

적용하신 구조에 맞춰 API를 추가했습니다.

추가된 endpoint

1.  /sender/count
2. /keyword/count

## 💡 To Reviewer

프론트에서 추가로 필요한 API들이라, 제작해서 추가했습니다.
만약 내부 로직을 변경해야 하면, 응답 형태만 유지하시면 되겠습니다.

## 🧪 테스트 결과

https://github.com/user-attachments/assets/d2f39b08-1ccd-4d3a-b8b7-78112aaed784

## ✅ 반영 브랜치
main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new endpoints to provide count-based summaries for keyword and sender details, allowing users to view aggregated counts grouped by topic category or sender with various filtering options.

- **Chores**
  - Updated configuration to ignore additional log files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->