### PR TITLE
[MG-26] fix: 구독 동기화 API 오류 수정 

### DIFF
--- a/mailgreen/app/schemas/mail.py
+++ b/mailgreen/app/schemas/mail.py
@@ -8,6 +8,7 @@ class MailOut(BaseModel):
     snippet: str | None
     received_at: str
     is_read: bool | None
+    starred: bool
 
     class Config:
         from_attributes = True

--- a/mailgreen/app/schemas/subscription.py
+++ b/mailgreen/app/schemas/subscription.py
@@ -1,16 +1,18 @@
 from pydantic import BaseModel
 from uuid import UUID
-from typing import Optional
+from typing import List
 
 
 class SubscriptionOut(BaseModel):
     id: UUID
     sender: str
-    subject: str | None
     unsubscribe_link: str
-
-    subject: Optional[str]
-    snippet: Optional[str]
 
     class Config:
         from_attributes = True
+
+
+class SubscriptionSyncResult(BaseModel):
+    success: bool
+    new_count: int
+    new_subscriptions: List[SubscriptionOut]

--- a/mailgreen/controller/keyword_controller.py
+++ b/mailgreen/controller/keyword_controller.py
@@ -6,7 +6,11 @@ from sqlalchemy.orm import Session
 from mailgreen.app.database import get_db
 from mailgreen.app.schemas.keyword import TopKeywordOut
 from mailgreen.app.schemas.mail import MailOut
-from mailgreen.services.keyword_service import get_top_keywords, get_keyword_details, get_keyword_details_count
+from mailgreen.services.keyword_service import (
+    get_top_keywords,
+    get_keyword_details,
+    get_keyword_details_count,
+)
 
 router = APIRouter(prefix="/keyword", tags=["keyword"])
 
@@ -53,19 +57,25 @@ async def keyword_details(
             snippet=m.snippet,
             received_at=m.received_at.isoformat(),
             is_read=m.is_read,
+            starred=("STARRED" in (m.labels or [])),
         )
         for m in mails
     ]
 
-@router.get('/counts')
+
+@router.get("/counts")
 async def keyword_sender_counts(
     user_id: str = Query(..., description="User UUID"),
     topic_id: int | None = Query(None, description="조회할 대주제 ID (MajorTopic.id)"),
     start_date: str | None = Query(None, description="조회 시작일 (YYYY-MM-DD)"),
     end_date: str | None = Query(None, description="조회 종료일 (YYYY-MM-DD)"),
     is_read: bool | None = Query(None, description="읽음 여부 필터 (true/false)"),
-    older_than_months: int | None = Query(None, description="지정 개월 이전 메일만 조회"),
-    min_size_mb: float | None = Query(None, description="필터 기준 메일 크기 (MB 단위)"),
+    older_than_months: int | None = Query(
+        None, description="지정 개월 이전 메일만 조회"
+    ),
+    min_size_mb: float | None = Query(
+        None, description="필터 기준 메일 크기 (MB 단위)"
+    ),
     db: Session = Depends(get_db),
 ):
     result = get_keyword_details_count(

--- a/mailgreen/controller/mail_controller.py
+++ b/mailgreen/controller/mail_controller.py
@@ -13,8 +13,12 @@ router = APIRouter(prefix="/mail", tags=["mail"])
 
 @router.post("/analyze")
 def analyze_mail(user_id: UUID, db: Session = Depends(get_db)) -> Dict[str, str]:
-    start_history_id = start_analysis_task(db, str(user_id))
-    return {"message": "분석을 시작했습니다.", "start_history_id": start_history_id}
+    info = start_analysis_task(db, str(user_id))
+    return {
+        "message": "분석을 시작했습니다.",
+        "task_id": info["task_id"],
+        "start_history_id": info["start_history_id"],
+    }
 
 
 @router.get("/progress/{task_id}")

--- a/mailgreen/controller/sender_controller.py
+++ b/mailgreen/controller/sender_controller.py
@@ -55,6 +55,7 @@ async def sender_details(
             snippet=m.snippet,
             received_at=m.received_at.isoformat(),
             is_read=m.is_read,
+            starred=("STARRED" in (m.labels or [])),
         )
         for m in mails
     ]


### PR DESCRIPTION
### ✨Feat
- `sender_details` 및 `keyword_details` 응답에  `STARRED` 포함 여부 반환
    - MailOut Pydantic 모델에 `starred` 필드 추가
    - 컨트롤러에서  `"STARRED"` 존재 여부 확인 후 bool 값 반환
- `start_analysis_task` 엔드포인트에서 Celery `task_id` 반환값에 추가

### 🐛 Fix
- 구독 동기화 오류 수정